### PR TITLE
Handle onFinish

### DIFF
--- a/src/components/Picker.tsx
+++ b/src/components/Picker.tsx
@@ -105,16 +105,17 @@ const PickerItem = ({
 
   const onGestureEvent =
     useAnimatedGestureHandler<PanGestureHandlerGestureEvent>({
+      // @ts-ignore
       onStart: (_event, ctx) => {
-        // @ts-ignore
         ctx.y = translateY.value;
         // triggered at the start of the pan gesture
       },
+      // @ts-ignore
       onActive: ({ translationY }, ctx) => {
-        // @ts-ignore
         translateY.value = translationY + ctx.y;
         // triggered on every frame of the pan gesture
       },
+      // @ts-ignore
       onEnd: ({ velocityY }) => {
         const snapPointY = snapPoint(translateY.value, velocityY, snapPoints);
         const index =Math.abs(Math.round(snapPointY / itemHeight));
@@ -122,8 +123,8 @@ const PickerItem = ({
         runOnJS(wrapper)(index);
         // triggered at the end of the pan gesture
       },
+      // @ts-ignore
       onFinish({velocityY}, isCanceledOrFailed) {
-        // @ts-ignore
         if(isCanceledOrFailed){
           const snapPointY = snapPoint(translateY.value, velocityY, snapPoints);
           const index = Math.abs(Math.round(snapPointY / itemHeight));

--- a/src/components/Picker.tsx
+++ b/src/components/Picker.tsx
@@ -107,11 +107,13 @@ const PickerItem = ({
     useAnimatedGestureHandler<PanGestureHandlerGestureEvent>({
       // @ts-ignore
       onStart: (_event, ctx) => {
+        // @ts-ignore
         ctx.y = translateY.value;
         // triggered at the start of the pan gesture
       },
       // @ts-ignore
       onActive: ({ translationY }, ctx) => {
+         // @ts-ignore
         translateY.value = translationY + ctx.y;
         // triggered on every frame of the pan gesture
       },

--- a/src/components/Picker.tsx
+++ b/src/components/Picker.tsx
@@ -122,7 +122,8 @@ const PickerItem = ({
         runOnJS(wrapper)(index);
         // triggered at the end of the pan gesture
       },
-      onFinish({velocityY}, ctx, isCanceledOrFailed) {
+      onFinish({velocityY}, isCanceledOrFailed) {
+        // @ts-ignore
         if(isCanceledOrFailed){
           const snapPointY = snapPoint(translateY.value, velocityY, snapPoints);
           const index = Math.abs(Math.round(snapPointY / itemHeight));

--- a/src/components/Picker.tsx
+++ b/src/components/Picker.tsx
@@ -7,6 +7,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import React from 'react';
+// @ts-ignore
 import Animated, {
   Easing,
   Extrapolate,
@@ -18,12 +19,14 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+// @ts-ignore
 import {
   PanGestureHandlerGestureEvent,
   PanGestureHandler,
   GestureHandlerRootView,
 } from 'react-native-gesture-handler';
 import { snapPoint } from 'react-native-redash';
+// @ts-ignore
 import MaskedView from '@react-native-masked-view/masked-view';
 
 export type PickerData = {

--- a/src/components/Picker.tsx
+++ b/src/components/Picker.tsx
@@ -117,7 +117,7 @@ const PickerItem = ({
       },
       onEnd: ({ velocityY }) => {
         const snapPointY = snapPoint(translateY.value, velocityY, snapPoints);
-        const index = Math.abs(snapPointY / itemHeight);
+        const index =Math.abs(Math.round(snapPointY / itemHeight));
         translateY.value = withTiming(snapPointY, timingConfig);
         runOnJS(wrapper)(index);
         // triggered at the end of the pan gesture
@@ -125,9 +125,12 @@ const PickerItem = ({
       onFinish({velocityY}, ctx, isCanceledOrFailed) {
         if(isCanceledOrFailed){
           const snapPointY = snapPoint(translateY.value, velocityY, snapPoints);
+          const index = Math.abs(Math.round(snapPointY / itemHeight));
           translateY.value = withTiming(snapPointY, timingConfig);
-      }
-      // triggred when gesture is outside of the pan gesture  
+          runOnJS(wrapper)(index);
+        }
+      },
+       // triggred when gesture is outside of the pan gesture  
     });
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: translateY.value }],

--- a/src/components/Picker.tsx
+++ b/src/components/Picker.tsx
@@ -122,6 +122,12 @@ const PickerItem = ({
         runOnJS(wrapper)(index);
         // triggered at the end of the pan gesture
       },
+      onFinish({velocityY}, ctx, isCanceledOrFailed) {
+        if(isCanceledOrFailed){
+          const snapPointY = snapPoint(translateY.value, velocityY, snapPoints);
+          translateY.value = withTiming(snapPointY, timingConfig);
+      }
+      // triggred when gesture is outside of the pan gesture  
     });
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: translateY.value }],


### PR DESCRIPTION
Adding onFinish to the GestureHandler to check if the gesture is outside of the pan gesture area so it can snap to the right snap point rather than stuck between two points.

Before:

https://user-images.githubusercontent.com/39528296/204658411-a39fc114-c0fc-44f5-a99a-0cb097a58fab.mp4


After:

https://user-images.githubusercontent.com/39528296/204658441-4d59e5aa-3186-45e2-b933-1295a7d99e86.mp4

